### PR TITLE
Change Travis badge link

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Vkontakte API Rust client library
 
 [![Join the chat at https://gitter.im/kstep/vkrs](https://badges.gitter.im/kstep/vkrs.svg)](https://gitter.im/kstep/vkrs)
-[![Travis CI build status](https://img.shields.io/travis/kstep/vkrs.png)](https://travis-ci.org/kstep/vkrs)
+[![Travis CI build status](https://travis-ci.org/kstep/vkrs.svg?branch=master)](https://travis-ci.org/kstep/vkrs)
 [![Downloads](https://img.shields.io/crates/d/vkrs.png)](https://crates.io/crates/vkrs)
 [![Version](https://img.shields.io/crates/v/vkrs.png)](https://crates.io/crates/vkrs)
 [![License MIT/Apache-2.0](https://img.shields.io/crates/l/vkrs.png)](https://crates.io/crates/vkrs)


### PR DESCRIPTION
I've changed link from img.shields.io to original travis-ci.org beacause it shows the correct information about master branch build state, not status of the last build. As you can see master is ok now, but build fails on PR, and so we get "red" badge. It mat confuse consumers.