### PR TITLE
Use `slice::iter` instead of `into_iter` to avoid future breakage

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -4,7 +4,7 @@ macro_rules! qs {
     ($($name:expr => $value:expr),+ $(,)*) => {
         ::url::form_urlencoded::Serializer::new(String::new()).extend_pairs([
             $(($name, $value)),*
-        ].into_iter().filter(|&&(_, v)| !v.is_empty())).finish()
+        ].iter().filter(|&&(_, v)| !v.is_empty())).finish()
     }
 }
 


### PR DESCRIPTION
`an_array.into_iter()` currently just works because of the autoref
feature, which then calls `<[T] as IntoIterator>::into_iter`. But
in the future, arrays will implement `IntoIterator`, too. In order
to avoid problems in the future, the call is replaced by `iter()`
which is shorter and more explicit.

A crater run showed that your crate is affected by a potential future 
change. See https://github.com/rust-lang/rust/pull/65819 for more information.